### PR TITLE
Remove semver check because Beat Games moment

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,16 +105,16 @@ async function Main() {
 		core.info("Adding mod entry to mod repo");
 
 		if (!repoMods.hasOwnProperty(modJson.packageVersion)) {
-			if (semver.valid(modJson.packageVersion)) {
-				repoMods[modJson.packageVersion] = [];
+			// if (semver.valid(modJson.packageVersion)) {
+			repoMods[modJson.packageVersion] = [];
 
-				const msg = `There were no mods found for the version ${modJson.packageVersion}, so a new verion entry was created`;
+			const msg = `There were no mods found for the version ${modJson.packageVersion}, so a new verion entry was created`;
 
-				core.warning(msg);
-				notes.push(msg);
-			} else {
-				throw `Version ${modJson.packageVersion} is invalid!`;
-			}
+			core.warning(msg);
+			notes.push(msg);
+			// } else {
+			// 	throw `Version ${modJson.packageVersion} is invalid!`;
+			// }
 		}
 
 		var isNewEntry = true;


### PR DESCRIPTION
Beat Games decided that versions should not follow semver anymore so this action kept failing. This PR fixes that issue by removing the semver check.